### PR TITLE
Fix issues with updating to biom 2.1.8

### DIFF
--- a/qurro/qarcoal.py
+++ b/qurro/qarcoal.py
@@ -80,8 +80,9 @@ def filter_and_join_taxonomy(feat_table, taxonomy, num_string, denom_string):
         raise ValueError(
             "No samples contain both numerator and denominator features!"
         )
-    tax_num_df = tax_num_df[samp_to_keep]
-    tax_denom_df = tax_denom_df[samp_to_keep]
+
+    tax_num_df = tax_num_df[samp_to_keep].sparse.to_dense()
+    tax_denom_df = tax_denom_df[samp_to_keep].sparse.to_dense()
     return tax_num_df, tax_denom_df
 
 

--- a/qurro/qarcoal.py
+++ b/qurro/qarcoal.py
@@ -35,9 +35,7 @@ def filter_and_join_taxonomy(feat_table, taxonomy, num_string, denom_string):
     # this is done here as well as later on based on samples w/o
     # matching features because of some problems with filtering
     # introducing NAs
-    feat_table_copy = feat_table.loc[
-        :, (feat_table != 0).any(axis=0)
-    ]
+    feat_table_copy = feat_table.loc[:, (feat_table != 0).any(axis=0)]
 
     # need to keep Taxon temporarily to match up with feature table
     # can immediately discard non-Taxon columns

--- a/qurro/qarcoal.py
+++ b/qurro/qarcoal.py
@@ -83,6 +83,7 @@ def filter_and_join_taxonomy(feat_table, taxonomy, num_string, denom_string):
     samp_to_keep = set(tax_num_df.columns).intersection(
         set(tax_denom_df.columns)
     )
+
     if not samp_to_keep:
         raise ValueError(
             "No samples contain both numerator and denominator features!"

--- a/qurro/qarcoal.py
+++ b/qurro/qarcoal.py
@@ -31,14 +31,12 @@ def filter_and_join_taxonomy(feat_table, taxonomy, num_string, denom_string):
         denom_df: pd.DataFrame of denominator features x samples
     """
 
-    feat_table_copy = feat_table.copy()
-
     # drop samples with total 0 features
     # this is done here as well as later on based on samples w/o
     # matching features because of some problems with filtering
     # introducing NAs
-    feat_table_copy = feat_table_copy.loc[
-        :, (feat_table_copy != 0).any(axis=0)
+    feat_table_copy = feat_table.loc[
+        :, (feat_table != 0).any(axis=0)
     ]
 
     # need to keep Taxon temporarily to match up with feature table

--- a/qurro/qarcoal.py
+++ b/qurro/qarcoal.py
@@ -49,9 +49,7 @@ def filter_and_join_taxonomy(feat_table, taxonomy, num_string, denom_string):
     # retain only features that are in both feature table and taxonomy
     # rsuffix provided in unlikely case that a sample is called Taxon
     taxonomy_joined_df = taxonomy.join(
-        feat_table_copy,
-        how="inner",
-        rsuffix="_q"
+        feat_table_copy, how="inner", rsuffix="_q"
     )
 
     num_indices = taxonomy_joined_df["Taxon"].str.contains(num_string)

--- a/qurro/tests/test_qarcoal.py
+++ b/qurro/tests/test_qarcoal.py
@@ -28,6 +28,27 @@ class TestTypes(TestPluginBase):
         )
 
 
+def _check_dataframe_equality(df1, df2):
+    """Helper function to test whether two dataframes are equal.
+
+    We are using this function instead of the inbuilt testing of dataframes
+    to avoid any issues with sparse structures.
+    """
+    assert df1.shape == df2.shape
+
+    # going to order columns and indices first
+    df1 = df1[sorted(df1.columns)]
+    df2 = df2[sorted(df2.columns)]
+
+    df1 = df1.reindex(sorted(df1.index))
+    df2 = df2.reindex(sorted(df2.index))
+
+    assert list(df1.index) == list(df2.index)
+    for col1, col2 in zip(df1.columns, df2.columns):
+        assert col1 == col2
+        np.testing.assert_equal(df1[col1].values, df2[col1].values)
+
+
 @pytest.fixture(scope="module")
 def get_mp_data():
     biom_url = os.path.join(MP_URL, "feature-table.biom")
@@ -263,9 +284,7 @@ class TestIrregularData:
         sample_order = ["S{}".format(i) for i in range(5)]
 
         table_num_taxon_filt = pd.DataFrame(table.loc[num_features])
-        table_num_taxon_filt = table_num_taxon_filt.sparse.to_dense()
         table_denom_taxon_filt = pd.DataFrame(table.loc[denom_features])
-        table_denom_taxon_filt = table_denom_taxon_filt.sparse.to_dense()
 
         num_df_taxon_filt = num_df.loc[num_features]
         denom_df_taxon_filt = denom_df.loc[denom_features]
@@ -278,8 +297,15 @@ class TestIrregularData:
         denom_df_taxon_filt = denom_df_taxon_filt[sample_order]
 
         # test that num/denom df accurately extract values from table
-        assert table_num_taxon_filt.equals(num_df_taxon_filt)
-        assert table_denom_taxon_filt.equals(denom_df_taxon_filt)
+        _check_dataframe_equality(
+            table_num_taxon_filt,
+            num_df_taxon_filt,
+        )
+
+        _check_dataframe_equality(
+            table_denom_taxon_filt,
+            denom_df_taxon_filt,
+        )
 
     def test_taxonomy_missing_features(self, get_testing_data):
         """Taxonomy file missing features that are present in feature table"""
@@ -318,19 +344,24 @@ class TestIrregularData:
 
         num_features = ["F3", "F4", "F5"]
         denom_features = ["F0", "F1", "F2"]
-        for col in ["Overlap1", "Overlap2"]:
-            table_num_taxon_filt = pd.Series(table.loc[num_features][col])
-            table_num_taxon_filt = table_num_taxon_filt.sparse.to_dense()
-            table_denom_taxon_filt = pd.Series(table.loc[denom_features][col])
-            table_denom_taxon_filt = table_denom_taxon_filt.sparse.to_dense()
 
-            num_df_taxon_filt = num_df.loc[num_features][col]
-            denom_df_taxon_filt = denom_df.loc[denom_features][col]
+        table_num_taxon_filt = table.loc[num_features]
+        table_denom_taxon_filt = table.loc[denom_features]
 
-            # test that num/denom df accurately extract table values for
-            #  Overlap1 and Overlap2
-            assert table_num_taxon_filt.equals(num_df_taxon_filt)
-            assert table_denom_taxon_filt.equals(denom_df_taxon_filt)
+        num_df_taxon_filt = num_df.loc[num_features]
+        denom_df_taxon_filt = denom_df.loc[denom_features]
+
+        # test that num/denom df accurately extract table values for
+        # Overlap1 and Overlap2
+        _check_dataframe_equality(
+            table_num_taxon_filt,
+            num_df_taxon_filt,
+        )
+
+        _check_dataframe_equality(
+            table_denom_taxon_filt,
+            denom_df_taxon_filt,
+        )
 
     def test_taxon_as_sample_name(self, get_testing_data):
         """Feature table has sample called Taxon"""
@@ -345,16 +376,22 @@ class TestIrregularData:
         # test that num/denom df accurately extract table values for Taxon
         num_features = ["F3", "F4", "F5"]
         denom_features = ["F0", "F1", "F2"]
-        table_num_taxon_filt = pd.Series(table.loc[num_features]["Taxon"])
-        table_num_taxon_filt = table_num_taxon_filt.sparse.to_dense()
-        table_denom_taxon_filt = pd.Series(table.loc[denom_features]["Taxon"])
-        table_denom_taxon_filt = table_denom_taxon_filt.sparse.to_dense()
 
-        num_df_taxon_filt = num_df.loc[num_features]["Taxon"]
-        denom_df_taxon_filt = denom_df.loc[denom_features]["Taxon"]
+        table_num_taxon_filt = table.loc[num_features]
+        table_denom_taxon_filt = table.loc[denom_features]
 
-        assert table_num_taxon_filt.equals(num_df_taxon_filt)
-        assert table_denom_taxon_filt.equals(denom_df_taxon_filt)
+        num_df_taxon_filt = num_df.loc[num_features]
+        denom_df_taxon_filt = denom_df.loc[denom_features]
+
+        _check_dataframe_equality(
+            num_df_taxon_filt,
+            table_num_taxon_filt,
+        )
+
+        _check_dataframe_equality(
+            denom_df_taxon_filt,
+            table_denom_taxon_filt,
+        )
 
     def test_large_numbers(self):
         """Test large numbers on which Qurro fails.

--- a/qurro/tests/test_qarcoal.py
+++ b/qurro/tests/test_qarcoal.py
@@ -298,13 +298,11 @@ class TestIrregularData:
 
         # test that num/denom df accurately extract values from table
         _check_dataframe_equality(
-            table_num_taxon_filt,
-            num_df_taxon_filt,
+            table_num_taxon_filt, num_df_taxon_filt,
         )
 
         _check_dataframe_equality(
-            table_denom_taxon_filt,
-            denom_df_taxon_filt,
+            table_denom_taxon_filt, denom_df_taxon_filt,
         )
 
     def test_taxonomy_missing_features(self, get_testing_data):
@@ -354,13 +352,11 @@ class TestIrregularData:
         # test that num/denom df accurately extract table values for
         # Overlap1 and Overlap2
         _check_dataframe_equality(
-            table_num_taxon_filt,
-            num_df_taxon_filt,
+            table_num_taxon_filt, num_df_taxon_filt,
         )
 
         _check_dataframe_equality(
-            table_denom_taxon_filt,
-            denom_df_taxon_filt,
+            table_denom_taxon_filt, denom_df_taxon_filt,
         )
 
     def test_taxon_as_sample_name(self, get_testing_data):
@@ -384,13 +380,11 @@ class TestIrregularData:
         denom_df_taxon_filt = denom_df.loc[denom_features]
 
         _check_dataframe_equality(
-            num_df_taxon_filt,
-            table_num_taxon_filt,
+            num_df_taxon_filt, table_num_taxon_filt,
         )
 
         _check_dataframe_equality(
-            denom_df_taxon_filt,
-            table_denom_taxon_filt,
+            denom_df_taxon_filt, table_denom_taxon_filt,
         )
 
     def test_large_numbers(self):

--- a/qurro/tests/test_qarcoal.py
+++ b/qurro/tests/test_qarcoal.py
@@ -263,7 +263,9 @@ class TestIrregularData:
         sample_order = ["S{}".format(i) for i in range(5)]
 
         table_num_taxon_filt = pd.DataFrame(table.loc[num_features])
+        table_num_taxon_filt = table_num_taxon_filt.sparse.to_dense()
         table_denom_taxon_filt = pd.DataFrame(table.loc[denom_features])
+        table_denom_taxon_filt = table_denom_taxon_filt.sparse.to_dense()
 
         num_df_taxon_filt = num_df.loc[num_features]
         denom_df_taxon_filt = denom_df.loc[denom_features]
@@ -318,7 +320,10 @@ class TestIrregularData:
         denom_features = ["F0", "F1", "F2"]
         for col in ["Overlap1", "Overlap2"]:
             table_num_taxon_filt = pd.Series(table.loc[num_features][col])
+            table_num_taxon_filt = table_num_taxon_filt.sparse.to_dense()
             table_denom_taxon_filt = pd.Series(table.loc[denom_features][col])
+            table_denom_taxon_filt = table_denom_taxon_filt.sparse.to_dense()
+
             num_df_taxon_filt = num_df.loc[num_features][col]
             denom_df_taxon_filt = denom_df.loc[denom_features][col]
 
@@ -341,7 +346,10 @@ class TestIrregularData:
         num_features = ["F3", "F4", "F5"]
         denom_features = ["F0", "F1", "F2"]
         table_num_taxon_filt = pd.Series(table.loc[num_features]["Taxon"])
+        table_num_taxon_filt = table_num_taxon_filt.sparse.to_dense()
         table_denom_taxon_filt = pd.Series(table.loc[denom_features]["Taxon"])
+        table_denom_taxon_filt = table_denom_taxon_filt.sparse.to_dense()
+
         num_df_taxon_filt = num_df.loc[num_features]["Taxon"]
         denom_df_taxon_filt = denom_df.loc[denom_features]["Taxon"]
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "altair == 3.1.0",
-        "biom-format[hdf5]>=2.1.8.post1",
+        "biom-format[hdf5]",
         "click",
         "numpy >= 1.12.0",
         "pandas >= 0.24.0",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "altair == 3.1.0",
-        "biom-format[hdf5]",
+        "biom-format[hdf5]>=2.1.8.post1",
         "click",
         "numpy >= 1.12.0",
         "pandas >= 0.24.0",


### PR DESCRIPTION
Closes #271 

The main issue seemed to be that the sparse pandas data structures diverged somehow while the values stayed the same in the Qarcoal tests. The `filter_and_join_taxonomy` dataframes are converted to dense, as there is no reason to keep them sparse.

Also fixes another issue where a column of all 0s would result in errant filtering by numerator/denominator features. Columns of all 0s are now dropped prior to any filtering as they don't contribute to the log-ratios anyway.