### PR TITLE
Add "Exclude metadata fields from exported data?" option

### DIFF
--- a/docs/demos/byrd/index.html
+++ b/docs/demos/byrd/index.html
@@ -468,7 +468,7 @@
                         <div class="input-group-prepend">
                             <label
                                 class="input-group-text"
-                                for="exclFieldsInSamplePlotDataCheckbox"
+                                for="exclSMFieldsInExportCheckbox"
                             >
                                 <span
                                     class="questionmark"
@@ -482,7 +482,7 @@
                             <div class="input-group-text">
                                 <input
                                     type="checkbox"
-                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                    id="exclSMFieldsInExportCheckbox"
                                 />
                             </div>
                         </div>

--- a/docs/demos/byrd/index.html
+++ b/docs/demos/byrd/index.html
@@ -454,7 +454,7 @@
                                     class="questionmark mr-0"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and its metadata values for the current x-axis and color fields."
+                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and (if the &#34;Exclude metadata fields from exported data?&#34; checkbox is checked) the sample's metadata values for the current x-axis and color fields."
                                 >
                                 </span>
                             </label>
@@ -464,6 +464,27 @@
                             >
                                 Export current sample plot data
                             </button>
+                        </div>
+                        <div class="input-group-prepend">
+                            <label
+                                class="input-group-text"
+                                for="exclFieldsInSamplePlotDataCheckbox"
+                            >
+                                <span
+                                    class="questionmark"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="When checked, metadata fields for the x-axis and selected color scheme will *not* be included in the exported TSV of the sample plot data -- so the exported TSV will only contain information about each sample's ID and current log-ratio. Including these fields (i.e. leaving this checkbox unchecked) is usually helpful, but if you want to merge these log-ratios back into the sample metadata then excluding these fields (i.e. checking this checkbox) can make that easier (since it'll avoid duplicating the metadata columns)."
+                                >
+                                </span>
+                                Exclude metadata fields from exported data?
+                            </label>
+                            <div class="input-group-text">
+                                <input
+                                    type="checkbox"
+                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                />
+                            </div>
                         </div>
                         <input
                             type="text"

--- a/docs/demos/byrd/js/display.js
+++ b/docs/demos/byrd/js/display.js
@@ -194,7 +194,7 @@ define([
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
                     },
-                    exclFieldsInSamplePlotDataCheckbox: function () {
+                    exclSMFieldsInExportCheckbox: function () {
                         display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {

--- a/docs/demos/byrd/js/display.js
+++ b/docs/demos/byrd/js/display.js
@@ -64,6 +64,14 @@ define([
             // the sample plot.
             this.sampleCount = this.sampleIDs.length;
 
+            // Boolean variable: true if we should exclude x-axis and color
+            // sample metadata fields from the exported sample plot TSV, and
+            // false if we should include these fields.
+            // This functionality is mostly here so that exported log-ratios
+            // can be merged with the original sample metadata file
+            // (relatively) painlessly. (This is done in the Gemelli tutorial.)
+            this.exclSMFieldsInExport = false;
+
             // a mapping from "reason" (i.e. "balance", "xAxis", "color") to
             // list of dropped sample IDs.
             //
@@ -185,6 +193,9 @@ define([
                     },
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
+                    },
+                    exclFieldsInSamplePlotDataCheckbox: function () {
+                        display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
                         await display.updateSamplePlotColorScheme("category");
@@ -1141,6 +1152,16 @@ define([
             }
         }
 
+        /* Updates this.exclSMFieldsInExport based on its corresponding
+         * checkbox's status. (See the documentation of this variable in the
+         * constructor for details on what this does.)
+         */
+        updateExclSMFieldsInExport() {
+            this.exclSMFieldsInExport = document.getElementById(
+                "exclFieldsInSamplePlotDataCheckbox"
+            ).checked;
+        }
+
         addSamplePlotBorders() {
             this.samplePlotJSON.mark.stroke = "#000000";
             this.samplePlotJSON.mark.strokeWidth = 0.5;
@@ -1362,16 +1383,23 @@ define([
         /* Exports data from the sample plot to a string that can be written to
          * a .tsv file for further analysis of these data.
          *
-         * If no points have been "drawn" on the sample plot -- i.e. they all
-         * have a qurro_balance attribute of null -- then this just returns an
-         * empty string.
+         * The number of columns in the exported data depends on
+         * this.exclSMFieldsInExport's value; if it's true then there will just
+         * be two columns (sample ID and log-ratio), and if it's false then
+         * there'll be four columns (sample ID, log-ratio, x-axis field, color
+         * field).
          */
         getSamplePlotData(currXField, currColorField) {
-            var outputTSV =
-                '"Sample ID"\tCurrent_Natural_Log_Ratio\t' +
-                RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
-                "\t" +
-                RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            var inclSMFields = !this.exclSMFieldsInExport;
+            // Set up TSV header
+            var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
+            if (inclSMFields) {
+                outputTSV +=
+                    '\t' +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            }
             var dataName = this.samplePlotJSON.data.name;
             // Get all of the data available to the sample plot
             // (Note that updateLogRatio() causes updates to samples'
@@ -1385,13 +1413,15 @@ define([
                 );
                 outputTSV +=
                     "\n" + currSampleID + "\t" + String(data[i].qurro_balance);
-                currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currXField])
-                );
-                currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currColorField])
-                );
-                outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                if (inclSMFields) {
+                    currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currXField])
+                    );
+                    currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currColorField])
+                    );
+                    outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                }
             }
             return outputTSV;
         }
@@ -1505,6 +1535,9 @@ define([
                 document.getElementById("boxplotCheckbox").checked = false;
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
+                // ... And the "exclude metadata fields" checkbox
+                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
+                    .checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/byrd/js/display.js
+++ b/docs/demos/byrd/js/display.js
@@ -1158,7 +1158,7 @@ define([
          */
         updateExclSMFieldsInExport() {
             this.exclSMFieldsInExport = document.getElementById(
-                "exclFieldsInSamplePlotDataCheckbox"
+                "exclSMFieldsInExportCheckbox"
             ).checked;
         }
 
@@ -1395,7 +1395,7 @@ define([
             var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
             if (inclSMFields) {
                 outputTSV +=
-                    '\t' +
+                    "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
                     "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
@@ -1536,8 +1536,9 @@ define([
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
                 // ... And the "exclude metadata fields" checkbox
-                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
-                    .checked = false;
+                document.getElementById(
+                    "exclSMFieldsInExportCheckbox"
+                ).checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/mackerel/index.html
+++ b/docs/demos/mackerel/index.html
@@ -468,7 +468,7 @@
                         <div class="input-group-prepend">
                             <label
                                 class="input-group-text"
-                                for="exclFieldsInSamplePlotDataCheckbox"
+                                for="exclSMFieldsInExportCheckbox"
                             >
                                 <span
                                     class="questionmark"
@@ -482,7 +482,7 @@
                             <div class="input-group-text">
                                 <input
                                     type="checkbox"
-                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                    id="exclSMFieldsInExportCheckbox"
                                 />
                             </div>
                         </div>

--- a/docs/demos/mackerel/index.html
+++ b/docs/demos/mackerel/index.html
@@ -454,7 +454,7 @@
                                     class="questionmark mr-0"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and its metadata values for the current x-axis and color fields."
+                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and (if the &#34;Exclude metadata fields from exported data?&#34; checkbox is checked) the sample's metadata values for the current x-axis and color fields."
                                 >
                                 </span>
                             </label>
@@ -464,6 +464,27 @@
                             >
                                 Export current sample plot data
                             </button>
+                        </div>
+                        <div class="input-group-prepend">
+                            <label
+                                class="input-group-text"
+                                for="exclFieldsInSamplePlotDataCheckbox"
+                            >
+                                <span
+                                    class="questionmark"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="When checked, metadata fields for the x-axis and selected color scheme will *not* be included in the exported TSV of the sample plot data -- so the exported TSV will only contain information about each sample's ID and current log-ratio. Including these fields (i.e. leaving this checkbox unchecked) is usually helpful, but if you want to merge these log-ratios back into the sample metadata then excluding these fields (i.e. checking this checkbox) can make that easier (since it'll avoid duplicating the metadata columns)."
+                                >
+                                </span>
+                                Exclude metadata fields from exported data?
+                            </label>
+                            <div class="input-group-text">
+                                <input
+                                    type="checkbox"
+                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                />
+                            </div>
                         </div>
                         <input
                             type="text"

--- a/docs/demos/mackerel/js/display.js
+++ b/docs/demos/mackerel/js/display.js
@@ -194,7 +194,7 @@ define([
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
                     },
-                    exclFieldsInSamplePlotDataCheckbox: function () {
+                    exclSMFieldsInExportCheckbox: function () {
                         display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {

--- a/docs/demos/mackerel/js/display.js
+++ b/docs/demos/mackerel/js/display.js
@@ -64,6 +64,14 @@ define([
             // the sample plot.
             this.sampleCount = this.sampleIDs.length;
 
+            // Boolean variable: true if we should exclude x-axis and color
+            // sample metadata fields from the exported sample plot TSV, and
+            // false if we should include these fields.
+            // This functionality is mostly here so that exported log-ratios
+            // can be merged with the original sample metadata file
+            // (relatively) painlessly. (This is done in the Gemelli tutorial.)
+            this.exclSMFieldsInExport = false;
+
             // a mapping from "reason" (i.e. "balance", "xAxis", "color") to
             // list of dropped sample IDs.
             //
@@ -185,6 +193,9 @@ define([
                     },
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
+                    },
+                    exclFieldsInSamplePlotDataCheckbox: function () {
+                        display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
                         await display.updateSamplePlotColorScheme("category");
@@ -1141,6 +1152,16 @@ define([
             }
         }
 
+        /* Updates this.exclSMFieldsInExport based on its corresponding
+         * checkbox's status. (See the documentation of this variable in the
+         * constructor for details on what this does.)
+         */
+        updateExclSMFieldsInExport() {
+            this.exclSMFieldsInExport = document.getElementById(
+                "exclFieldsInSamplePlotDataCheckbox"
+            ).checked;
+        }
+
         addSamplePlotBorders() {
             this.samplePlotJSON.mark.stroke = "#000000";
             this.samplePlotJSON.mark.strokeWidth = 0.5;
@@ -1362,16 +1383,23 @@ define([
         /* Exports data from the sample plot to a string that can be written to
          * a .tsv file for further analysis of these data.
          *
-         * If no points have been "drawn" on the sample plot -- i.e. they all
-         * have a qurro_balance attribute of null -- then this just returns an
-         * empty string.
+         * The number of columns in the exported data depends on
+         * this.exclSMFieldsInExport's value; if it's true then there will just
+         * be two columns (sample ID and log-ratio), and if it's false then
+         * there'll be four columns (sample ID, log-ratio, x-axis field, color
+         * field).
          */
         getSamplePlotData(currXField, currColorField) {
-            var outputTSV =
-                '"Sample ID"\tCurrent_Natural_Log_Ratio\t' +
-                RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
-                "\t" +
-                RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            var inclSMFields = !this.exclSMFieldsInExport;
+            // Set up TSV header
+            var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
+            if (inclSMFields) {
+                outputTSV +=
+                    '\t' +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            }
             var dataName = this.samplePlotJSON.data.name;
             // Get all of the data available to the sample plot
             // (Note that updateLogRatio() causes updates to samples'
@@ -1385,13 +1413,15 @@ define([
                 );
                 outputTSV +=
                     "\n" + currSampleID + "\t" + String(data[i].qurro_balance);
-                currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currXField])
-                );
-                currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currColorField])
-                );
-                outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                if (inclSMFields) {
+                    currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currXField])
+                    );
+                    currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currColorField])
+                    );
+                    outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                }
             }
             return outputTSV;
         }
@@ -1505,6 +1535,9 @@ define([
                 document.getElementById("boxplotCheckbox").checked = false;
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
+                // ... And the "exclude metadata fields" checkbox
+                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
+                    .checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/mackerel/js/display.js
+++ b/docs/demos/mackerel/js/display.js
@@ -1158,7 +1158,7 @@ define([
          */
         updateExclSMFieldsInExport() {
             this.exclSMFieldsInExport = document.getElementById(
-                "exclFieldsInSamplePlotDataCheckbox"
+                "exclSMFieldsInExportCheckbox"
             ).checked;
         }
 
@@ -1395,7 +1395,7 @@ define([
             var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
             if (inclSMFields) {
                 outputTSV +=
-                    '\t' +
+                    "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
                     "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
@@ -1536,8 +1536,9 @@ define([
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
                 // ... And the "exclude metadata fields" checkbox
-                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
-                    .checked = false;
+                document.getElementById(
+                    "exclSMFieldsInExportCheckbox"
+                ).checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/q2_moving_pictures/index.html
+++ b/docs/demos/q2_moving_pictures/index.html
@@ -468,7 +468,7 @@
                         <div class="input-group-prepend">
                             <label
                                 class="input-group-text"
-                                for="exclFieldsInSamplePlotDataCheckbox"
+                                for="exclSMFieldsInExportCheckbox"
                             >
                                 <span
                                     class="questionmark"
@@ -482,7 +482,7 @@
                             <div class="input-group-text">
                                 <input
                                     type="checkbox"
-                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                    id="exclSMFieldsInExportCheckbox"
                                 />
                             </div>
                         </div>

--- a/docs/demos/q2_moving_pictures/index.html
+++ b/docs/demos/q2_moving_pictures/index.html
@@ -454,7 +454,7 @@
                                     class="questionmark mr-0"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and its metadata values for the current x-axis and color fields."
+                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and (if the &#34;Exclude metadata fields from exported data?&#34; checkbox is checked) the sample's metadata values for the current x-axis and color fields."
                                 >
                                 </span>
                             </label>
@@ -464,6 +464,27 @@
                             >
                                 Export current sample plot data
                             </button>
+                        </div>
+                        <div class="input-group-prepend">
+                            <label
+                                class="input-group-text"
+                                for="exclFieldsInSamplePlotDataCheckbox"
+                            >
+                                <span
+                                    class="questionmark"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="When checked, metadata fields for the x-axis and selected color scheme will *not* be included in the exported TSV of the sample plot data -- so the exported TSV will only contain information about each sample's ID and current log-ratio. Including these fields (i.e. leaving this checkbox unchecked) is usually helpful, but if you want to merge these log-ratios back into the sample metadata then excluding these fields (i.e. checking this checkbox) can make that easier (since it'll avoid duplicating the metadata columns)."
+                                >
+                                </span>
+                                Exclude metadata fields from exported data?
+                            </label>
+                            <div class="input-group-text">
+                                <input
+                                    type="checkbox"
+                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                />
+                            </div>
                         </div>
                         <input
                             type="text"

--- a/docs/demos/q2_moving_pictures/js/display.js
+++ b/docs/demos/q2_moving_pictures/js/display.js
@@ -194,7 +194,7 @@ define([
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
                     },
-                    exclFieldsInSamplePlotDataCheckbox: function () {
+                    exclSMFieldsInExportCheckbox: function () {
                         display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {

--- a/docs/demos/q2_moving_pictures/js/display.js
+++ b/docs/demos/q2_moving_pictures/js/display.js
@@ -64,6 +64,14 @@ define([
             // the sample plot.
             this.sampleCount = this.sampleIDs.length;
 
+            // Boolean variable: true if we should exclude x-axis and color
+            // sample metadata fields from the exported sample plot TSV, and
+            // false if we should include these fields.
+            // This functionality is mostly here so that exported log-ratios
+            // can be merged with the original sample metadata file
+            // (relatively) painlessly. (This is done in the Gemelli tutorial.)
+            this.exclSMFieldsInExport = false;
+
             // a mapping from "reason" (i.e. "balance", "xAxis", "color") to
             // list of dropped sample IDs.
             //
@@ -185,6 +193,9 @@ define([
                     },
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
+                    },
+                    exclFieldsInSamplePlotDataCheckbox: function () {
+                        display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
                         await display.updateSamplePlotColorScheme("category");
@@ -1141,6 +1152,16 @@ define([
             }
         }
 
+        /* Updates this.exclSMFieldsInExport based on its corresponding
+         * checkbox's status. (See the documentation of this variable in the
+         * constructor for details on what this does.)
+         */
+        updateExclSMFieldsInExport() {
+            this.exclSMFieldsInExport = document.getElementById(
+                "exclFieldsInSamplePlotDataCheckbox"
+            ).checked;
+        }
+
         addSamplePlotBorders() {
             this.samplePlotJSON.mark.stroke = "#000000";
             this.samplePlotJSON.mark.strokeWidth = 0.5;
@@ -1362,16 +1383,23 @@ define([
         /* Exports data from the sample plot to a string that can be written to
          * a .tsv file for further analysis of these data.
          *
-         * If no points have been "drawn" on the sample plot -- i.e. they all
-         * have a qurro_balance attribute of null -- then this just returns an
-         * empty string.
+         * The number of columns in the exported data depends on
+         * this.exclSMFieldsInExport's value; if it's true then there will just
+         * be two columns (sample ID and log-ratio), and if it's false then
+         * there'll be four columns (sample ID, log-ratio, x-axis field, color
+         * field).
          */
         getSamplePlotData(currXField, currColorField) {
-            var outputTSV =
-                '"Sample ID"\tCurrent_Natural_Log_Ratio\t' +
-                RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
-                "\t" +
-                RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            var inclSMFields = !this.exclSMFieldsInExport;
+            // Set up TSV header
+            var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
+            if (inclSMFields) {
+                outputTSV +=
+                    '\t' +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            }
             var dataName = this.samplePlotJSON.data.name;
             // Get all of the data available to the sample plot
             // (Note that updateLogRatio() causes updates to samples'
@@ -1385,13 +1413,15 @@ define([
                 );
                 outputTSV +=
                     "\n" + currSampleID + "\t" + String(data[i].qurro_balance);
-                currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currXField])
-                );
-                currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currColorField])
-                );
-                outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                if (inclSMFields) {
+                    currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currXField])
+                    );
+                    currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currColorField])
+                    );
+                    outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                }
             }
             return outputTSV;
         }
@@ -1505,6 +1535,9 @@ define([
                 document.getElementById("boxplotCheckbox").checked = false;
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
+                // ... And the "exclude metadata fields" checkbox
+                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
+                    .checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/q2_moving_pictures/js/display.js
+++ b/docs/demos/q2_moving_pictures/js/display.js
@@ -1158,7 +1158,7 @@ define([
          */
         updateExclSMFieldsInExport() {
             this.exclSMFieldsInExport = document.getElementById(
-                "exclFieldsInSamplePlotDataCheckbox"
+                "exclSMFieldsInExportCheckbox"
             ).checked;
         }
 
@@ -1395,7 +1395,7 @@ define([
             var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
             if (inclSMFields) {
                 outputTSV +=
-                    '\t' +
+                    "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
                     "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
@@ -1536,8 +1536,9 @@ define([
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
                 // ... And the "exclude metadata fields" checkbox
-                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
-                    .checked = false;
+                document.getElementById(
+                    "exclSMFieldsInExportCheckbox"
+                ).checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/red_sea/index.html
+++ b/docs/demos/red_sea/index.html
@@ -468,7 +468,7 @@
                         <div class="input-group-prepend">
                             <label
                                 class="input-group-text"
-                                for="exclFieldsInSamplePlotDataCheckbox"
+                                for="exclSMFieldsInExportCheckbox"
                             >
                                 <span
                                     class="questionmark"
@@ -482,7 +482,7 @@
                             <div class="input-group-text">
                                 <input
                                     type="checkbox"
-                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                    id="exclSMFieldsInExportCheckbox"
                                 />
                             </div>
                         </div>

--- a/docs/demos/red_sea/index.html
+++ b/docs/demos/red_sea/index.html
@@ -454,7 +454,7 @@
                                     class="questionmark mr-0"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and its metadata values for the current x-axis and color fields."
+                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and (if the &#34;Exclude metadata fields from exported data?&#34; checkbox is checked) the sample's metadata values for the current x-axis and color fields."
                                 >
                                 </span>
                             </label>
@@ -464,6 +464,27 @@
                             >
                                 Export current sample plot data
                             </button>
+                        </div>
+                        <div class="input-group-prepend">
+                            <label
+                                class="input-group-text"
+                                for="exclFieldsInSamplePlotDataCheckbox"
+                            >
+                                <span
+                                    class="questionmark"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="When checked, metadata fields for the x-axis and selected color scheme will *not* be included in the exported TSV of the sample plot data -- so the exported TSV will only contain information about each sample's ID and current log-ratio. Including these fields (i.e. leaving this checkbox unchecked) is usually helpful, but if you want to merge these log-ratios back into the sample metadata then excluding these fields (i.e. checking this checkbox) can make that easier (since it'll avoid duplicating the metadata columns)."
+                                >
+                                </span>
+                                Exclude metadata fields from exported data?
+                            </label>
+                            <div class="input-group-text">
+                                <input
+                                    type="checkbox"
+                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                />
+                            </div>
                         </div>
                         <input
                             type="text"

--- a/docs/demos/red_sea/js/display.js
+++ b/docs/demos/red_sea/js/display.js
@@ -194,7 +194,7 @@ define([
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
                     },
-                    exclFieldsInSamplePlotDataCheckbox: function () {
+                    exclSMFieldsInExportCheckbox: function () {
                         display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {

--- a/docs/demos/red_sea/js/display.js
+++ b/docs/demos/red_sea/js/display.js
@@ -64,6 +64,14 @@ define([
             // the sample plot.
             this.sampleCount = this.sampleIDs.length;
 
+            // Boolean variable: true if we should exclude x-axis and color
+            // sample metadata fields from the exported sample plot TSV, and
+            // false if we should include these fields.
+            // This functionality is mostly here so that exported log-ratios
+            // can be merged with the original sample metadata file
+            // (relatively) painlessly. (This is done in the Gemelli tutorial.)
+            this.exclSMFieldsInExport = false;
+
             // a mapping from "reason" (i.e. "balance", "xAxis", "color") to
             // list of dropped sample IDs.
             //
@@ -185,6 +193,9 @@ define([
                     },
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
+                    },
+                    exclFieldsInSamplePlotDataCheckbox: function () {
+                        display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
                         await display.updateSamplePlotColorScheme("category");
@@ -1141,6 +1152,16 @@ define([
             }
         }
 
+        /* Updates this.exclSMFieldsInExport based on its corresponding
+         * checkbox's status. (See the documentation of this variable in the
+         * constructor for details on what this does.)
+         */
+        updateExclSMFieldsInExport() {
+            this.exclSMFieldsInExport = document.getElementById(
+                "exclFieldsInSamplePlotDataCheckbox"
+            ).checked;
+        }
+
         addSamplePlotBorders() {
             this.samplePlotJSON.mark.stroke = "#000000";
             this.samplePlotJSON.mark.strokeWidth = 0.5;
@@ -1362,16 +1383,23 @@ define([
         /* Exports data from the sample plot to a string that can be written to
          * a .tsv file for further analysis of these data.
          *
-         * If no points have been "drawn" on the sample plot -- i.e. they all
-         * have a qurro_balance attribute of null -- then this just returns an
-         * empty string.
+         * The number of columns in the exported data depends on
+         * this.exclSMFieldsInExport's value; if it's true then there will just
+         * be two columns (sample ID and log-ratio), and if it's false then
+         * there'll be four columns (sample ID, log-ratio, x-axis field, color
+         * field).
          */
         getSamplePlotData(currXField, currColorField) {
-            var outputTSV =
-                '"Sample ID"\tCurrent_Natural_Log_Ratio\t' +
-                RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
-                "\t" +
-                RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            var inclSMFields = !this.exclSMFieldsInExport;
+            // Set up TSV header
+            var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
+            if (inclSMFields) {
+                outputTSV +=
+                    '\t' +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            }
             var dataName = this.samplePlotJSON.data.name;
             // Get all of the data available to the sample plot
             // (Note that updateLogRatio() causes updates to samples'
@@ -1385,13 +1413,15 @@ define([
                 );
                 outputTSV +=
                     "\n" + currSampleID + "\t" + String(data[i].qurro_balance);
-                currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currXField])
-                );
-                currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currColorField])
-                );
-                outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                if (inclSMFields) {
+                    currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currXField])
+                    );
+                    currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currColorField])
+                    );
+                    outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                }
             }
             return outputTSV;
         }
@@ -1505,6 +1535,9 @@ define([
                 document.getElementById("boxplotCheckbox").checked = false;
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
+                // ... And the "exclude metadata fields" checkbox
+                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
+                    .checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/red_sea/js/display.js
+++ b/docs/demos/red_sea/js/display.js
@@ -1158,7 +1158,7 @@ define([
          */
         updateExclSMFieldsInExport() {
             this.exclSMFieldsInExport = document.getElementById(
-                "exclFieldsInSamplePlotDataCheckbox"
+                "exclSMFieldsInExportCheckbox"
             ).checked;
         }
 
@@ -1395,7 +1395,7 @@ define([
             var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
             if (inclSMFields) {
                 outputTSV +=
-                    '\t' +
+                    "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
                     "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
@@ -1536,8 +1536,9 @@ define([
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
                 // ... And the "exclude metadata fields" checkbox
-                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
-                    .checked = false;
+                document.getElementById(
+                    "exclSMFieldsInExportCheckbox"
+                ).checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/sleep_apnea/index.html
+++ b/docs/demos/sleep_apnea/index.html
@@ -468,7 +468,7 @@
                         <div class="input-group-prepend">
                             <label
                                 class="input-group-text"
-                                for="exclFieldsInSamplePlotDataCheckbox"
+                                for="exclSMFieldsInExportCheckbox"
                             >
                                 <span
                                     class="questionmark"
@@ -482,7 +482,7 @@
                             <div class="input-group-text">
                                 <input
                                     type="checkbox"
-                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                    id="exclSMFieldsInExportCheckbox"
                                 />
                             </div>
                         </div>

--- a/docs/demos/sleep_apnea/index.html
+++ b/docs/demos/sleep_apnea/index.html
@@ -454,7 +454,7 @@
                                     class="questionmark mr-0"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and its metadata values for the current x-axis and color fields."
+                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and (if the &#34;Exclude metadata fields from exported data?&#34; checkbox is checked) the sample's metadata values for the current x-axis and color fields."
                                 >
                                 </span>
                             </label>
@@ -464,6 +464,27 @@
                             >
                                 Export current sample plot data
                             </button>
+                        </div>
+                        <div class="input-group-prepend">
+                            <label
+                                class="input-group-text"
+                                for="exclFieldsInSamplePlotDataCheckbox"
+                            >
+                                <span
+                                    class="questionmark"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="When checked, metadata fields for the x-axis and selected color scheme will *not* be included in the exported TSV of the sample plot data -- so the exported TSV will only contain information about each sample's ID and current log-ratio. Including these fields (i.e. leaving this checkbox unchecked) is usually helpful, but if you want to merge these log-ratios back into the sample metadata then excluding these fields (i.e. checking this checkbox) can make that easier (since it'll avoid duplicating the metadata columns)."
+                                >
+                                </span>
+                                Exclude metadata fields from exported data?
+                            </label>
+                            <div class="input-group-text">
+                                <input
+                                    type="checkbox"
+                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                />
+                            </div>
                         </div>
                         <input
                             type="text"

--- a/docs/demos/sleep_apnea/js/display.js
+++ b/docs/demos/sleep_apnea/js/display.js
@@ -194,7 +194,7 @@ define([
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
                     },
-                    exclFieldsInSamplePlotDataCheckbox: function () {
+                    exclSMFieldsInExportCheckbox: function () {
                         display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {

--- a/docs/demos/sleep_apnea/js/display.js
+++ b/docs/demos/sleep_apnea/js/display.js
@@ -64,6 +64,14 @@ define([
             // the sample plot.
             this.sampleCount = this.sampleIDs.length;
 
+            // Boolean variable: true if we should exclude x-axis and color
+            // sample metadata fields from the exported sample plot TSV, and
+            // false if we should include these fields.
+            // This functionality is mostly here so that exported log-ratios
+            // can be merged with the original sample metadata file
+            // (relatively) painlessly. (This is done in the Gemelli tutorial.)
+            this.exclSMFieldsInExport = false;
+
             // a mapping from "reason" (i.e. "balance", "xAxis", "color") to
             // list of dropped sample IDs.
             //
@@ -185,6 +193,9 @@ define([
                     },
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
+                    },
+                    exclFieldsInSamplePlotDataCheckbox: function () {
+                        display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
                         await display.updateSamplePlotColorScheme("category");
@@ -1141,6 +1152,16 @@ define([
             }
         }
 
+        /* Updates this.exclSMFieldsInExport based on its corresponding
+         * checkbox's status. (See the documentation of this variable in the
+         * constructor for details on what this does.)
+         */
+        updateExclSMFieldsInExport() {
+            this.exclSMFieldsInExport = document.getElementById(
+                "exclFieldsInSamplePlotDataCheckbox"
+            ).checked;
+        }
+
         addSamplePlotBorders() {
             this.samplePlotJSON.mark.stroke = "#000000";
             this.samplePlotJSON.mark.strokeWidth = 0.5;
@@ -1362,16 +1383,23 @@ define([
         /* Exports data from the sample plot to a string that can be written to
          * a .tsv file for further analysis of these data.
          *
-         * If no points have been "drawn" on the sample plot -- i.e. they all
-         * have a qurro_balance attribute of null -- then this just returns an
-         * empty string.
+         * The number of columns in the exported data depends on
+         * this.exclSMFieldsInExport's value; if it's true then there will just
+         * be two columns (sample ID and log-ratio), and if it's false then
+         * there'll be four columns (sample ID, log-ratio, x-axis field, color
+         * field).
          */
         getSamplePlotData(currXField, currColorField) {
-            var outputTSV =
-                '"Sample ID"\tCurrent_Natural_Log_Ratio\t' +
-                RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
-                "\t" +
-                RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            var inclSMFields = !this.exclSMFieldsInExport;
+            // Set up TSV header
+            var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
+            if (inclSMFields) {
+                outputTSV +=
+                    '\t' +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            }
             var dataName = this.samplePlotJSON.data.name;
             // Get all of the data available to the sample plot
             // (Note that updateLogRatio() causes updates to samples'
@@ -1385,13 +1413,15 @@ define([
                 );
                 outputTSV +=
                     "\n" + currSampleID + "\t" + String(data[i].qurro_balance);
-                currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currXField])
-                );
-                currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currColorField])
-                );
-                outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                if (inclSMFields) {
+                    currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currXField])
+                    );
+                    currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currColorField])
+                    );
+                    outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                }
             }
             return outputTSV;
         }
@@ -1505,6 +1535,9 @@ define([
                 document.getElementById("boxplotCheckbox").checked = false;
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
+                // ... And the "exclude metadata fields" checkbox
+                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
+                    .checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/docs/demos/sleep_apnea/js/display.js
+++ b/docs/demos/sleep_apnea/js/display.js
@@ -1158,7 +1158,7 @@ define([
          */
         updateExclSMFieldsInExport() {
             this.exclSMFieldsInExport = document.getElementById(
-                "exclFieldsInSamplePlotDataCheckbox"
+                "exclSMFieldsInExportCheckbox"
             ).checked;
         }
 
@@ -1395,7 +1395,7 @@ define([
             var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
             if (inclSMFields) {
                 outputTSV +=
-                    '\t' +
+                    "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
                     "\t" +
                     RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
@@ -1536,8 +1536,9 @@ define([
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
                 // ... And the "exclude metadata fields" checkbox
-                document.getElementById("exclFieldsInSamplePlotDataCheckbox")
-                    .checked = false;
+                document.getElementById(
+                    "exclSMFieldsInExportCheckbox"
+                ).checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/qurro/support_files/index.html
+++ b/qurro/support_files/index.html
@@ -454,7 +454,7 @@
                                     class="questionmark mr-0"
                                     data-toggle="tooltip"
                                     data-placement="top"
-                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and its metadata values for the current x-axis and color fields."
+                                    title="This button exports a TSV file describing the data underlying the sample plot. Below the header row in the TSV file, each row contains a sample's ID along with the sample's currently selected log-ratio and (if the &#34;Exclude metadata fields from exported data?&#34; checkbox is checked) the sample's metadata values for the current x-axis and color fields."
                                 >
                                 </span>
                             </label>
@@ -464,6 +464,27 @@
                             >
                                 Export current sample plot data
                             </button>
+                        </div>
+                        <div class="input-group-prepend">
+                            <label
+                                class="input-group-text"
+                                for="exclFieldsInSamplePlotDataCheckbox"
+                            >
+                                <span
+                                    class="questionmark"
+                                    data-toggle="tooltip"
+                                    data-placement="top"
+                                    title="When checked, metadata fields for the x-axis and selected color scheme will *not* be included in the exported TSV of the sample plot data -- so the exported TSV will only contain information about each sample's ID and current log-ratio. Including these fields (i.e. leaving this checkbox unchecked) is usually helpful, but if you want to merge these log-ratios back into the sample metadata then excluding these fields (i.e. checking this checkbox) can make that easier (since it'll avoid duplicating the metadata columns)."
+                                >
+                                </span>
+                                Exclude metadata fields from exported data?
+                            </label>
+                            <div class="input-group-text">
+                                <input
+                                    type="checkbox"
+                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                />
+                            </div>
                         </div>
                         <input
                             type="text"

--- a/qurro/support_files/index.html
+++ b/qurro/support_files/index.html
@@ -468,7 +468,7 @@
                         <div class="input-group-prepend">
                             <label
                                 class="input-group-text"
-                                for="exclFieldsInSamplePlotDataCheckbox"
+                                for="exclSMFieldsInExportCheckbox"
                             >
                                 <span
                                     class="questionmark"

--- a/qurro/support_files/index.html
+++ b/qurro/support_files/index.html
@@ -482,7 +482,7 @@
                             <div class="input-group-text">
                                 <input
                                     type="checkbox"
-                                    id="exclFieldsInSamplePlotDataCheckbox"
+                                    id="exclSMFieldsInExportCheckbox"
                                 />
                             </div>
                         </div>

--- a/qurro/support_files/js/display.js
+++ b/qurro/support_files/js/display.js
@@ -64,6 +64,14 @@ define([
             // the sample plot.
             this.sampleCount = this.sampleIDs.length;
 
+            // Boolean variable: true if we should exclude x-axis and color
+            // sample metadata fields from the exported sample plot TSV, and
+            // false if we should include these fields.
+            // This functionality is mostly here so that exported log-ratios
+            // can be merged with the original sample metadata file
+            // (relatively) painlessly. (This is done in the Gemelli tutorial.)
+            this.exclSMFieldsInExport = false;
+
             // a mapping from "reason" (i.e. "balance", "xAxis", "color") to
             // list of dropped sample IDs.
             //
@@ -185,6 +193,9 @@ define([
                     },
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
+                    },
+                    exclFieldsInSamplePlotDataCheckbox: function () {
+                        display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
                         await display.updateSamplePlotColorScheme("category");
@@ -1141,6 +1152,16 @@ define([
             }
         }
 
+        /* Updates this.exclSMFieldsInExport based on its corresponding
+         * checkbox's status. (See the documentation of this variable in the
+         * constructor for details on what this does.)
+         */
+        updateExclSMFieldsInExport() {
+            this.exclSMFieldsInExport = document.getElementById(
+                "exclFieldsInSamplePlotDataCheckbox"
+            ).checked;
+        }
+
         addSamplePlotBorders() {
             this.samplePlotJSON.mark.stroke = "#000000";
             this.samplePlotJSON.mark.strokeWidth = 0.5;
@@ -1362,16 +1383,23 @@ define([
         /* Exports data from the sample plot to a string that can be written to
          * a .tsv file for further analysis of these data.
          *
-         * If no points have been "drawn" on the sample plot -- i.e. they all
-         * have a qurro_balance attribute of null -- then this just returns an
-         * empty string.
+         * The number of columns in the exported data depends on
+         * this.exclSMFieldsInExport's value; if it's true then there will just
+         * be two columns (sample ID and log-ratio), and if it's false then
+         * there'll be four columns (sample ID, log-ratio, x-axis field, color
+         * field).
          */
         getSamplePlotData(currXField, currColorField) {
-            var outputTSV =
-                '"Sample ID"\tCurrent_Natural_Log_Ratio\t' +
-                RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
-                "\t" +
-                RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            var inclSMFields = !this.exclSMFieldsInExport;
+            // Set up TSV header
+            var outputTSV = '"Sample ID"\tCurrent_Natural_Log_Ratio';
+            if (inclSMFields) {
+                outputTSV +=
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currXField) +
+                    "\t" +
+                    RRVDisplay.quoteTSVFieldIfNeeded(currColorField);
+            }
             var dataName = this.samplePlotJSON.data.name;
             // Get all of the data available to the sample plot
             // (Note that updateLogRatio() causes updates to samples'
@@ -1385,13 +1413,15 @@ define([
                 );
                 outputTSV +=
                     "\n" + currSampleID + "\t" + String(data[i].qurro_balance);
-                currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currXField])
-                );
-                currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
-                    String(data[i][currColorField])
-                );
-                outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                if (inclSMFields) {
+                    currXValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currXField])
+                    );
+                    currColorValue = RRVDisplay.quoteTSVFieldIfNeeded(
+                        String(data[i][currColorField])
+                    );
+                    outputTSV += "\t" + currXValue + "\t" + currColorValue;
+                }
             }
             return outputTSV;
         }
@@ -1505,6 +1535,10 @@ define([
                 document.getElementById("boxplotCheckbox").checked = false;
                 // ... And the sample border checkbox
                 document.getElementById("borderCheckbox").checked = false;
+                // ... And the "exclude metadata fields" checkbox
+                document.getElementById(
+                    "exclFieldsInSamplePlotDataCheckbox"
+                ).checked = false;
 
                 // Enable the elements that would've been disabled if we were
                 // in boxplot mode

--- a/qurro/support_files/js/display.js
+++ b/qurro/support_files/js/display.js
@@ -194,7 +194,7 @@ define([
                     borderCheckbox: async function () {
                         await display.updateSamplePlotBorders();
                     },
-                    exclFieldsInSamplePlotDataCheckbox: function () {
+                    exclSMFieldsInExportCheckbox: function () {
                         display.updateExclSMFieldsInExport();
                     },
                     catColorScheme: async function () {
@@ -1158,7 +1158,7 @@ define([
          */
         updateExclSMFieldsInExport() {
             this.exclSMFieldsInExport = document.getElementById(
-                "exclFieldsInSamplePlotDataCheckbox"
+                "exclSMFieldsInExportCheckbox"
             ).checked;
         }
 
@@ -1537,7 +1537,7 @@ define([
                 document.getElementById("borderCheckbox").checked = false;
                 // ... And the "exclude metadata fields" checkbox
                 document.getElementById(
-                    "exclFieldsInSamplePlotDataCheckbox"
+                    "exclSMFieldsInExportCheckbox"
                 ).checked = false;
 
                 // Enable the elements that would've been disabled if we were

--- a/qurro/tests/web_tests/index.html
+++ b/qurro/tests/web_tests/index.html
@@ -127,7 +127,7 @@
         </select>
         <input type="checkbox" id="boxplotCheckbox" />
         <input type="checkbox" id="borderCheckbox" />
-        <input type="checkbox" id="exclFieldsInSamplePlotDataCheckbox" />
+        <input type="checkbox" id="exclSMFieldsInExportCheckbox" />
         <button id="multiFeatureButton"></button>
         <button id="exportRankPlotDataButton"></button>
         <button id="exportSamplePlotDataButton"></button>

--- a/qurro/tests/web_tests/index.html
+++ b/qurro/tests/web_tests/index.html
@@ -127,6 +127,7 @@
         </select>
         <input type="checkbox" id="boxplotCheckbox" />
         <input type="checkbox" id="borderCheckbox" />
+        <input type="checkbox" id="exclFieldsInSamplePlotDataCheckbox" />
         <button id="multiFeatureButton"></button>
         <button id="exportRankPlotDataButton"></button>
         <button id="exportSamplePlotDataButton"></button>

--- a/qurro/tests/web_tests/tests/test_rrvdisplay_destroy.js
+++ b/qurro/tests/web_tests/tests/test_rrvdisplay_destroy.js
@@ -71,6 +71,9 @@ define(["vega", "dom_utils", "mocha", "chai", "testing_utilities"], function (
             // calling destroy()
             await document.getElementById("borderCheckbox").click();
             await document.getElementById("boxplotCheckbox").click();
+            await document
+                .getElementById("exclSMFieldsInExportCheckbox")
+                .click();
             document.getElementById("topSearchType").value = "rank";
             document.getElementById("botSearchType").value = "rank";
             document.getElementById("topText").value = "Test top search text";

--- a/qurro/tests/web_tests/tests/test_rrvdisplay_destroy.js
+++ b/qurro/tests/web_tests/tests/test_rrvdisplay_destroy.js
@@ -112,6 +112,9 @@ define(["vega", "dom_utils", "mocha", "chai", "testing_utilities"], function (
             chai.assert.isFalse(
                 document.getElementById("boxplotCheckbox").checked
             );
+            chai.assert.isFalse(
+                document.getElementById("exclSMFieldsInExportCheckbox").checked
+            );
             // Check that boxplot mode "disabled" elements were enabled
             chai.assert.isFalse(document.getElementById("colorField").disabled);
             chai.assert.isFalse(document.getElementById("colorScale").disabled);


### PR DESCRIPTION
Closes #306, and should make merging log-ratios with sample metadata easier (as is done in the [Gemelli](https://github.com/biocore/gemelli) tutorials, e.g. [here](https://github.com/biocore/gemelli/blob/master/ipynb/tutorials/IBD-Tutorial-QIIME2-API.ipynb)).