### PR TITLE
BLD: only send cov reports to codecov from Q2 CI

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -40,5 +40,9 @@ jobs:
           make pytest_standalone
           make jstest
 
-      - name: Upload code coverage information to Codecov
-        uses: codecov/codecov-action@v2
+      # NOTE: For now, we only submit coverage reports from the QIIME 2 CI,
+      # since the tests that that CI runs are a superset of those ran by this
+      # "standalone" CI. (Also, Codecov wasn't merging them, which caused
+      # coverage to be underreported.)
+      # - name: Upload code coverage information to Codecov
+      #   uses: codecov/codecov-action@v2


### PR DESCRIPTION
Codecov wasn't merging the Q2 and standalone CI coverage reports properly -- it was just looking at the standalone report, as far as I can tell. This caused coverage to be underreported; that isn't a big deal, but I'd like to fix it if possible.

I think this PR should fix the issue, since the Q2 CI's tests are a superset of those run from the standalone CI.